### PR TITLE
Preserve size information in diff mode

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -560,16 +560,20 @@ void Rollup::CreateRows(RollupRow* row, const Rollup* base,
       child_row.size.vm = vm_total;
       child_row.size.file = file_total;
 
+      // Preserve the old and new sizes for this label in the RollupRow output.
+      // If there is a diff base, the old sizes come from the size of the label
+      // in that base.  Otherwise, the old size is the same as the new (current)
+      // size.
       if (base_child) {
-        child_row.original_size.vm = base_child->vm_total_;
-        child_row.original_size.file = base_child->file_total_;
-        child_row.current_size.vm = value.second->vm_total_;
-        child_row.current_size.file = value.second->file_total_;
+        child_row.old_size.vm = base_child->vm_total_;
+        child_row.old_size.file = base_child->file_total_;
+        child_row.new_size.vm = value.second->vm_total_;
+        child_row.new_size.file = value.second->file_total_;
       } else {
-        child_row.original_size.vm = child_row.size.vm;
-        child_row.original_size.file = child_row.size.file;
-        child_row.current_size.vm = child_row.size.vm;
-        child_row.current_size.file = child_row.size.file;
+        child_row.old_size.vm = child_row.size.vm;
+        child_row.old_size.file = child_row.size.file;
+        child_row.new_size.vm = child_row.size.vm;
+        child_row.new_size.file = child_row.size.file;
       }
     }
   }
@@ -634,10 +638,10 @@ void Rollup::SortAndAggregateRows(RollupRow* row, const Rollup* base,
     CheckedAdd(&others_row.size.vm, child_rows[i].size.vm);
     CheckedAdd(&others_row.size.file, child_rows[i].size.file);
 
-    CheckedAdd(&others_row.current_size.vm, child_rows[i].current_size.vm);
-    CheckedAdd(&others_row.current_size.file, child_rows[i].current_size.file);
-    CheckedAdd(&others_row.original_size.vm, child_rows[i].original_size.vm);
-    CheckedAdd(&others_row.original_size.file, child_rows[i].original_size.file);
+    CheckedAdd(&others_row.new_size.vm, child_rows[i].new_size.vm);
+    CheckedAdd(&others_row.new_size.file, child_rows[i].new_size.file);
+    CheckedAdd(&others_row.old_size.vm, child_rows[i].old_size.vm);
+    CheckedAdd(&others_row.old_size.file, child_rows[i].old_size.file);
 
     if (base) {
       auto it = base->children_.find(child_rows[i].name);
@@ -937,10 +941,10 @@ void RollupOutput::PrintRowToCSV(const RollupRow& row,
   parent_labels.push_back(std::to_string(row.size.file));
   parent_labels.push_back(std::to_string(row.capacity.vm));
   parent_labels.push_back(std::to_string(row.capacity.file));
-  parent_labels.push_back(std::to_string(row.original_size.vm));
-  parent_labels.push_back(std::to_string(row.original_size.file));
-  parent_labels.push_back(std::to_string(row.current_size.vm));
-  parent_labels.push_back(std::to_string(row.current_size.file));
+  parent_labels.push_back(std::to_string(row.old_size.vm));
+  parent_labels.push_back(std::to_string(row.old_size.file));
+  parent_labels.push_back(std::to_string(row.new_size.vm));
+  parent_labels.push_back(std::to_string(row.new_size.file));
 
   std::string sep = tabs ? "\t" : ",";
   *out << absl::StrJoin(parent_labels, sep) << "\n";

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -449,8 +449,11 @@ struct RollupRow {
   double vmpercent;
   double filepercent;
   DomainSizes capacity = {0, 0};
-  DomainSizes original_size = {0, 0};
-  DomainSizes current_size = {0, 0};
+  // The size of this row in a diff base.  Same as `size` for non-diff.
+  DomainSizes old_size = {0, 0};
+  // The current size of this row (this is not the same as `size` in the case
+  // of a diff -- `size` is the delta).
+  DomainSizes new_size = {0, 0};
   CapacityOrigin capacity_origin = CapacityOrigin::kInherited;
   std::vector<RollupRow> sorted_children;
 

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -433,20 +433,24 @@ enum CapacityOrigin {
   kBothSet   = 3,
 };
 
+struct DomainSizes {
+  int64_t vm;
+  int64_t file;
+};
+
 struct RollupRow {
   RollupRow(const std::string& name_) : name(name_) {}
 
   std::string name;
-  int64_t vmsize = 0;
-  int64_t filesize = 0;
-  int64_t filtered_vmsize = 0;
-  int64_t filtered_filesize = 0;
+  DomainSizes size = {0, 0};
+  DomainSizes filtered_size = {0, 0};
   int64_t other_count = 0;
   int64_t sortkey;
   double vmpercent;
   double filepercent;
-  int64_t vmcapacity = 0;
-  int64_t filecapacity = 0;
+  DomainSizes capacity = {0, 0};
+  DomainSizes original_size = {0, 0};
+  DomainSizes current_size = {0, 0};
   CapacityOrigin capacity_origin = CapacityOrigin::kInherited;
   std::vector<RollupRow> sorted_children;
 

--- a/tests/bloaty_misc_test.cc
+++ b/tests/bloaty_misc_test.cc
@@ -27,7 +27,7 @@ TEST_F(BloatyTest, InlinesOnSmallFile) {
       {"bloaty", "-d", "compileunits", "03-small-binary-that-crashed-inlines.bin"});
   RunBloaty(
       {"bloaty", "-d", "inlines", "03-small-binary-that-crashed-inlines.bin"});
-  EXPECT_EQ(top_row_->vmsize, 2340);
+  EXPECT_EQ(top_row_->size.vm, 2340);
 }
 
 TEST_F(BloatyTest, GoBinary) {
@@ -39,7 +39,7 @@ TEST_F(BloatyTest, GoBinary) {
 
 TEST_F(BloatyTest, MultiThreaded) {
   RunBloaty({"bloaty", "02-section-count-overflow.o"});
-  size_t file_size = top_row_->filesize;
+  size_t file_size = top_row_->size.file;
 
   // Bloaty doesn't know or care that you are passing the same file multiple
   // times.
@@ -49,5 +49,5 @@ TEST_F(BloatyTest, MultiThreaded) {
     args.push_back("02-section-count-overflow.o");
   }
   RunBloaty(args);  // Heavily multithreaded test.
-  EXPECT_EQ(top_row_->filesize, file_size * 100);
+  EXPECT_EQ(top_row_->size.file, file_size * 100);
 }

--- a/tests/bloaty_test.cc
+++ b/tests/bloaty_test.cc
@@ -19,22 +19,22 @@ TEST_F(BloatyTest, EmptyObjectFile) {
   uint64_t size;
   ASSERT_TRUE(GetFileSize(file, &size));
 
-  // Empty .c file should result in a .o file with no vmsize.
+  // Empty .c file should result in a .o file with no size.vm.
   RunBloaty({"bloaty", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with segments (we fake segments on .o files).
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with symbols.
   RunBloaty({"bloaty", "-d", "symbols", file});
-  EXPECT_EQ(top_row_->vmsize, 0);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_EQ(top_row_->size.vm, 0);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // We can't run any of these targets against object files.
@@ -50,16 +50,16 @@ TEST_F(BloatyTest, SimpleObjectFile) {
 
   // Test "-n 0" which should return an unlimited number of rows.
   RunBloaty({"bloaty", "-n", "0", file});
-  EXPECT_GT(top_row_->vmsize, 64);
-  EXPECT_LT(top_row_->vmsize, 300);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 64);
+  EXPECT_LT(top_row_->size.vm, 300);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // Same with segments (we fake segments on .o files).
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 64);
-  EXPECT_LT(top_row_->vmsize, 300);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 64);
+  EXPECT_LT(top_row_->size.vm, 300);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
   // For inputfiles we should get everything attributed to the input file.
@@ -111,15 +111,15 @@ TEST_F(BloatyTest, SimpleArchiveFile) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  //EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  //EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  //EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  //EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "40", "-s", "vm", file});
   AssertChildren(*top_row_, {
@@ -174,15 +174,15 @@ TEST_F(BloatyTest, SimpleSharedObjectFile) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "50", file});
   AssertChildren(*top_row_, {
@@ -202,15 +202,15 @@ TEST_F(BloatyTest, SimpleBinary) {
   ASSERT_TRUE(GetFileSize(file, &size));
 
   RunBloaty({"bloaty", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 3);
 
   RunBloaty({"bloaty", "-d", "segments", file});
-  EXPECT_GT(top_row_->vmsize, 8000);
-  EXPECT_LT(top_row_->vmsize, 12000);
-  EXPECT_EQ(top_row_->filesize, size);
+  EXPECT_GT(top_row_->size.vm, 8000);
+  EXPECT_LT(top_row_->size.vm, 12000);
+  EXPECT_EQ(top_row_->size.file, size);
 
   RunBloaty({"bloaty", "-d", "symbols", "-n", "50", "-s", "vm", file});
   AssertChildren(*top_row_, {

--- a/tests/test.h
+++ b/tests/test.h
@@ -77,16 +77,16 @@ class BloatyTest : public ::testing::Test {
       uint64_t vmtotal = 0;
       uint64_t filetotal = 0;
       for (const auto& child : row.sorted_children) {
-        vmtotal += child.vmsize;
-        filetotal += child.filesize;
+        vmtotal += child.size.vm;
+        filetotal += child.size.file;
         CheckConsistencyForRow(child, false, diff_mode, count);
         ASSERT_TRUE(names.insert(child.name).second);
-        ASSERT_FALSE(child.vmsize == 0 && child.filesize == 0);
+        ASSERT_FALSE(child.size.vm == 0 && child.size.file == 0);
       }
 
       if (!diff_mode) {
-        ASSERT_EQ(vmtotal, row.vmsize);
-        ASSERT_EQ(filetotal, row.filesize);
+        ASSERT_EQ(vmtotal, row.size.vm);
+        ASSERT_EQ(filetotal, row.size.file);
       }
     } else {
       // Count leaf rows.
@@ -143,7 +143,7 @@ class BloatyTest : public ::testing::Test {
         ASSERT_TRUE(GetFileSize(filename, &size));
         total_input_size += size;
       }
-      ASSERT_EQ(top_row_->filesize, total_input_size);
+      ASSERT_EQ(top_row_->size.file, total_input_size);
     }
 
     int rows = 0;
@@ -244,21 +244,21 @@ class BloatyTest : public ::testing::Test {
       if (expected_vm == kUnknown) {
         // Always pass.
       } else if (expected_vm > 0) {
-        EXPECT_GE(child.vmsize, expected_vm);
+        EXPECT_GE(child.size.vm, expected_vm);
         // Allow some overhead.
-        EXPECT_LE(child.vmsize, (expected_vm * 1.1) + 100);
+        EXPECT_LE(child.size.vm, (expected_vm * 1.1) + 100);
       } else {
         ASSERT_TRUE(false);
       }
 
       if (expected_file == kSameAsVM) {
-        expected_file = child.vmsize;
+        expected_file = child.size.vm;
       }
 
       if (expected_file != kUnknown) {
-        EXPECT_GE(child.filesize, expected_file);
+        EXPECT_GE(child.size.file, expected_file);
         // Allow some overhead.
-        EXPECT_LE(child.filesize, (expected_file * 1.2) + 180);
+        EXPECT_LE(child.size.file, (expected_file * 1.2) + 180);
       }
 
       if (++i == children.size()) {


### PR DESCRIPTION
To perform a diff, Bloaty would previously subtract the sizes in the
base file's Rollup from the current file's and pass the resulting
Rollup to be unrolled and printed. This had the unfortunate side effect
of discarding the new and old size data for each label, leaving only the
size difference. This size data is useful when labels in a binary have
capacities associated with them.

This change modifies the way Bloaty performs diffs by moving the size
subtraction further along in the process, when creating RollupRows.
Original and current sizes are added to the RollupRow struct and set
when each row is created to preserve all size information for each
label. Bloaty's default pretty-printed output is unchanged, but the
[CT]SV output is modified to include additional columns for original
and current label sizes.